### PR TITLE
consent modülü hakkında

### DIFF
--- a/HOWTO-SimpleSAMLphp/Identity Provider/ssp-v1.x-UbuntuServer-20.04.02LTS/ReadMe.md
+++ b/HOWTO-SimpleSAMLphp/Identity Provider/ssp-v1.x-UbuntuServer-20.04.02LTS/ReadMe.md
@@ -492,12 +492,13 @@ Kurulumda, kurumun kimlik doğrulama için LDAP kullandığı varsayımı yapıl
 
                // consent (rıza) modulu. Secimler cerezlerde saklaniyor.
                // ayarlar icin: https://simplesamlphp.org/docs/stable/consent:consent
+	       /*
                97 => [
                    'class' => 'consent:Consent',
                    'store' => 'consent:Cookie',
                    'focus' => 'yes',
                    'checked' => false
-               ],
+               ],*/
 
                // If language is set in Consent module it will be added as an attribute
                99 => 'core:LanguageAdaptor',


### PR DESCRIPTION
Modül güncel olmadığı için yeni versiyon simplesamlphp ile sorun yaşatıyor. 
saml20-idp-hosted.php de yer alan tanımda 

97 => [
                   'class' => 'consent:Consent',
                   'store' => 'consent:Cookie',
                   'focus' => 'yes',
                   'checked' => false
               ],
yeterli gelmiyor. Çünkü modülün 

https://github.com/simplesamlphp/simplesamlphp-module-consent/blob/7026cc1cd7006e995860a346f843d439bc45b1e7/lib/Auth/Process/Consent.php#L177
 Assert::keyExists($config, 'identifyingAttribute', "Consent: Missing mandatory 'identifyingAttribute' config setting.");

ifadesi geçiyor. Yukarıdaki yapılandırmada "identifyingAttribute" bileşeni yer almadığı için bu satırda hata alıyorsunuz. Bu nedenle ilk etapta config dosyasını şu şekilde yapılandırmak gerekti

97 => [
                   'class' => 'consent:Consent',
                   'store' => 'consent:Cookie',
                   'focus' => 'yes',
                   'checked' => false,
                   'identifyingAttribute' =>'mail' // test amaçlı
               ],

yapılan bu ayar değişikliği ile sorun çözülüyor fakat, bu sefer de modül fonksiyonları eski kaldığı için hata almaya başlıyorsunuz.

https://github.com/simplesamlphp/simplesamlphp-module-consent/blob/7026cc1cd7006e995860a346f843d439bc45b1e7/www/getconsent.php#L134
$translator->t() fonksiyonu tanımsız uyarısı vermeye başlıyor.

Konuyla ilgili bir issue var. Tamamlanmış bir çözüm değil, php versiyonu ile ilişkili de olabilir. Php 8 de bazı tanımlar değişmişti.
https://github.com/simplesamlphp/simplesamlphp-module-consent/issues/10

97 nolu anahtarı iptal ederek yolumuza devam ettik.